### PR TITLE
Sync'd with 1.0.2's changes to the system ABI (Ricardian contracts untouched)

### DIFF
--- a/eosio.system/eosio.system.abi
+++ b/eosio.system/eosio.system.abi
@@ -909,6 +909,15 @@
           "type": "connector"
         }
       ]
+    }, {
+      "name": "namebid_info",
+      "base": "",
+      "fields": [
+         {"name":"newname", "type":"account_name"},
+         {"name":"high_bidder", "type":"account_name"},
+         {"name":"high_bid", "type":"int64"},
+         {"name":"last_bid_time", "type":"uint64"}
+      ]
     }
   ],
   "actions": [
@@ -1131,6 +1140,12 @@
       "key_types": [
         "uint64"
       ]
+    },{
+      "name": "namebids",
+      "type": "namebid_info",
+      "index_type": "i64",
+      "key_names" : ["newname"],
+      "key_types" : ["account_name"]
     }
   ],
   "ricardian_clauses": [


### PR DESCRIPTION
See: https://github.com/EOSIO/eos/commit/102a099074ff7116a67b60785595641cc9dd85f0
